### PR TITLE
Use game input field for blueprint search

### DIFF
--- a/BlueprintSearchBar/BlueprintSearchBar/Patches.cs
+++ b/BlueprintSearchBar/BlueprintSearchBar/Patches.cs
@@ -31,7 +31,7 @@ public static class Patches
         outlineRect.localScale = Vector3.one;
         outlineRect.localPosition = new Vector3(-472.5f, 310f, 0f);
 
-        var inputField = outline.AddComponent<TMP_InputField>();
+        var inputField = outline.AddComponent<uGUI_InputField>();
         var normalText = CreateTextChild(outline, "Text");
         inputField.textComponent = normalText;
         normalText.fontStyle = FontStyles.UpperCase;


### PR DESCRIPTION
The search box was using TMP_InputField directly, so typing WASD could still reach player movement.

This switches it to the game's uGUI_InputField, matching the vanilla input behavior that locks movement while typing.

Tested:
- `dotnet build BlueprintSearchBar/BlueprintSearchBar/BlueprintSearchBar.csproj -c Release`
- checked in-game that typing in blueprint search no longer moves the player